### PR TITLE
Added loading config secrets from env instead of secrets.py

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM python:3.7
+WORKDIR /usr/src/app
 COPY . .
 RUN pip install -r requirements.txt
 CMD ["python3", "main.py"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+version: "3.9"
+services:
+  bot:
+    build: .
+    volumes:
+      - ./peewee.db:/usr/src/app/peewee.db
+    environment:
+      - TELEGRAM_BOT_TOKEN=
+      - TWITTER_ACCESS_TOKEN=
+      - TWITTER_ACCESS_TOKEN_SECRET=
+      - TWITTER_CONSUMER_SECRET=
+      - TWITTER_CONSUMER_KEY=


### PR DESCRIPTION
This is a pretty simple change that enables the loading of the secrets through env vars, making it safer to use this project in a docker-compose or in some similar server deployment, since we don't need to bake secrets into the docker image anymore. I also included a docker-compose as an example for the docker images. It's admittedly pretty sloppy, but it works and I wanted to change it in the smallest way I could to add this without changing any of the later KeyError-based try catch statements. 

If there's any more changes you want me to make, just let me know.

On another note, I'd really appreciate it if you could set this up to build into a docker container automatically every update. As an example, here is how I have done it on another project, using github actions and docker hub https://github.com/JakeCover/PersonalWebsite_GraphQL_Api/blob/main/.github/workflows/docker.yml. If not that's totally fine too, thank you for making this!